### PR TITLE
Remove user proxies when using Tor

### DIFF
--- a/requests_tor.py
+++ b/requests_tor.py
@@ -67,7 +67,7 @@ class RequestsTor():
         port = next(self.ports)
 
         # if using requests_tor as drop in replacement for requests remove any user set proxies
-        if hasattr(kwargs, "proxies"):
+        if kwargs.__contains__("proxies"):
             del kwargs["proxies"]
                     
         proxies = {"http": f"socks5h://localhost:{port}",

--- a/requests_tor.py
+++ b/requests_tor.py
@@ -65,8 +65,14 @@ class RequestsTor():
 
     def request(self, method, url, **kwargs):
         port = next(self.ports)
+
+        # if using requests_tor as drop in replacement for requests remove any user set proxies
+        if hasattr(kwargs, "proxies"):
+            del kwargs["proxies"]
+                    
         proxies = {"http": f"socks5h://localhost:{port}",
                    "https": f"socks5h://localhost:{port}"}
+        
         kwargs["headers"] = kwargs.get("headers", TOR_HEADERS)
         resp = requests.request(method, url, **kwargs, proxies=proxies)
         print(f"SocksPort={port} status={resp.status_code} url={resp.url}")


### PR DESCRIPTION
request library can set proxies, this breaks the package. Delete proxies so that we can set our own.