### PR TITLE
Added a max_retries option

### DIFF
--- a/requests_tor.py
+++ b/requests_tor.py
@@ -73,7 +73,7 @@ class RequestsTor:
                 "'verbose' parameter is deprecated. Use logging.basicConfig(level=logging.INFO)."
             )
         self.logger = logging.getLogger(__name__)
-        self.amx_retries = max_retries
+        self.max_retries = max_retries
 
     def new_id(self):
         with Controller.from_port(port=self.tor_cport) as controller:


### PR DESCRIPTION
Added an optional "max_retries" parameter (default 5) for when the exit node on the Tor network times out.  Should we receive a ConnectionError, regenerate a new ID and try again until we've reached our max_retries.  If we still don't get a response, return an official ConnectionError.